### PR TITLE
make sidebar have sans-serif font

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -156,7 +156,7 @@ h1, h2, h3, h4, h5 {
 	height: 0;
 }
 .sidebar {
-	font-family: Lato;
+	font-family: "Myriad Pro","Lucida Grande","Lucida Sans Unicode","Lucida Sans",Geneva,Verdana,sans-serif;
 	background: #262626 url(images/bg/sidebar.png);
 	position: fixed;
 	overflow: hidden;


### PR DESCRIPTION
Nice work looks good!

I’m sure you’re not really maintaining this, but just took a look at it and thought the sidebar looked off. Seeing the original design on Svpply, it used sans-serif font in the sidebar: https://www.google.com/search?q=svpply+category+navigation+design&tbm=isch

This re-uses the same font-family you have for your h1–h6 elements.

Given the width of “Interaction Design” you might also want to change the following to `.sidebar #scrollMe a { padding: 0 15px; }`

Cheers.
